### PR TITLE
Remove synthetic default imports in ts definitions

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,5 +1,5 @@
-import Compose from 'koa-compose'
-import Router from 'koa-router'
+import * as Compose from 'koa-compose'
+import * as Router from 'koa-router'
 
 type Middleware = Compose.ComposedMiddleware<Router.IRouterContext>
 


### PR DESCRIPTION
When the `allowSyntheticDefaultImports` option in Typescript is set to `false` (like it is by default), using this module fails.

This is because `koa-compose` and `koa-router` are imported as `import Compose from 'koa-compose`, while these pacakges don't have a default export.

This generates the following error message:
```
node_modules/koa-combine-routers/index.d.ts(1,8): error TS1192: Module '"node_modules/@types/koa-compose/index"' has no default export.

node_modules/koa-combine-routers/index.d.ts(2,8): error TS1192: Module '"node_modules/@types/koa-router/index"' has no default export.
```

To make this work without synthetic default imports, this must be changed to `import * as Compose from 'koa-compose'`. This pull request does just that.